### PR TITLE
feat: enable drive file upload for problems

### DIFF
--- a/src/components/EssayForm.tsx
+++ b/src/components/EssayForm.tsx
@@ -64,6 +64,20 @@ const EssayForm: React.FC<EssayFormProps> = ({ problems, onFormSubmit, isLoading
                 <div key={problem.id} className="border-t border-slate-200 pt-6">
                     <h3 className="font-semibold text-lg text-slate-800">{problem.title}</h3>
                     <p className="text-slate-600 mt-1 mb-4">{problem.description}</p>
+                    {problem.attachmentUrl && (
+                        problem.attachmentType === 'image' ? (
+                            <img src={problem.attachmentUrl} alt="첨부 이미지" className="mb-4 max-w-full h-auto" />
+                        ) : (
+                            <a
+                              href={problem.attachmentUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-blue-600 underline mb-4 block"
+                            >
+                              첨부 파일 보기
+                            </a>
+                        )
+                    )}
                     <textarea
                         rows={8}
                         value={answers[problem.id] || ''}

--- a/src/services/googleDriveService.ts
+++ b/src/services/googleDriveService.ts
@@ -73,3 +73,25 @@ export async function saveSubmissionToSheet(submission: Submission): Promise<{ s
 
   return { sheetUrl };
 }
+
+/**
+ * Simulates uploading a file to Google Drive.
+ * Returns a dummy URL representing the uploaded file.
+ */
+export async function uploadFile(file: File): Promise<{ fileUrl: string }> {
+  console.log("Simulating file upload to Google Drive:", file.name);
+
+  if (!isSignedIn) {
+    throw new Error("Google 계정에 로그인해야 합니다.");
+  }
+
+  // Simulate network delay
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // Return a fake Drive file URL
+  const mockFileId = `file_${Date.now()}`;
+  const fileUrl = `https://drive.google.com/file/d/${mockFileId}/view`;
+  console.log(`Mock file uploaded at: ${fileUrl}`);
+
+  return { fileUrl };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ export interface Problem {
   id: string;
   title: string;
   description: string;
+  attachmentUrl?: string;
+  attachmentType?: 'image' | 'pdf';
 }
 
 export interface SubmissionFormData {


### PR DESCRIPTION
## Summary
- allow teachers to attach image/PDF files to custom problems
- mock upload of selected files to Google Drive and store URLs on the problem
- show attached images or PDF links when students view problems

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895d56f73e88327b1c1da7b70c1d7ef